### PR TITLE
feat: pull company logos from Airtable

### DIFF
--- a/app/api/companies/route.ts
+++ b/app/api/companies/route.ts
@@ -60,9 +60,17 @@ export async function GET(req: Request) {
     const data = await fetchAirtable(apiUrl);
     const items = (data.records as AirtableRecord[]).map((rec) => {
       let logoUrl: string | undefined;
-      const logo = rec.fields?.Logo as any;
-      if (Array.isArray(logo) && logo.length && logo[0]?.url) {
-        logoUrl = logo[0].url as string;
+      const logoKeys = ['Logo', 'Company Logo', 'logo', 'Image', 'Logo URL'];
+      for (const key of logoKeys) {
+        const val = (rec.fields as any)[key];
+        if (Array.isArray(val) && val.length && val[0]?.url) {
+          logoUrl = val[0].url as string;
+          break;
+        }
+        if (typeof val === 'string' && val.trim().length > 0) {
+          logoUrl = val.trim();
+          break;
+        }
       }
       return { id: rec.id, fields: rec.fields, logoUrl };
     });

--- a/components/companies/logo.ts
+++ b/components/companies/logo.ts
@@ -13,10 +13,11 @@ export function deriveLogoUrl(record: { fields: Record<string, any>, logoUrl?: s
   }
 
   const fields = record?.fields || {};
-  const keys = ["Company Logo", "Logo", "logo", "Image"];
+  const keys = ["Company Logo", "Logo", "logo", "Image", "Logo URL"];
   for (const k of keys) {
     const atts = (fields as any)[k];
     if (Array.isArray(atts) && atts.length && atts[0]?.url) return String(atts[0].url);
+    if (typeof atts === "string" && atts.trim().length > 0) return atts.trim();
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary
- support additional Airtable logo fields including string URLs
- update API to surface logo URLs for company cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c1ab28f49c83209817c1a81bbd4b19