### PR TITLE
Expand Airtable company fetch and dynamic sector filters

### DIFF
--- a/app/api/companies/route.ts
+++ b/app/api/companies/route.ts
@@ -7,7 +7,8 @@ const CACHE_CLEAR_TOKEN = process.env.CACHE_CLEAR_TOKEN;
 
 const BASE_ID = process.env.AIRTABLE_BASE_ID || 'appAswQzYFHzmwqGH';
 const TABLE_NAME = process.env.AIRTABLE_TABLE_NAME || 'Companies';
-const VIEW_NAME = process.env.AIRTABLE_VIEW_NAME || 'JBView (Live)';
+// Do not default to a specific view so new records aren't inadvertently hidden
+const VIEW_NAME = process.env.AIRTABLE_VIEW_NAME;
 const API_KEY = process.env.AIRTABLE_API_KEY || process.env.AIRTABLE_API_TOKEN || process.env.AIRTABLE_PAT;
 
 type AirtableRecord = { id: string; fields: Record<string, any> };
@@ -49,7 +50,7 @@ export async function GET(req: Request) {
 
   const apiUrl = `https://api.airtable.com/v0/${encodeURIComponent(BASE_ID)}/${encodeURIComponent(
     TABLE_NAME
-  )}?view=${encodeURIComponent(VIEW_NAME)}&pageSize=50${offset ? `&offset=${encodeURIComponent(offset)}` : ''}`;
+  )}?pageSize=50${VIEW_NAME ? `&view=${encodeURIComponent(VIEW_NAME)}` : ''}${offset ? `&offset=${encodeURIComponent(offset)}` : ''}`;
 
   const cacheKey = apiUrl;
   const cached = simpleCache.get<any>(cacheKey);

--- a/app/companies/page.tsx
+++ b/app/companies/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 export const dynamic = "force-dynamic";
 import { Suspense, useMemo, useState, useEffect } from "react";
-import { companies, sectors } from "@/lib/companies";
+import { companies } from "@/lib/companies";
 import FilterChips from "@/components/FilterChips";
 import CompaniesGridA16z from "@/components/companies/CompaniesGridA16z";
 import CompanyModalA16z from "@/components/companies/CompanyModalA16z";
@@ -64,10 +64,16 @@ function CompaniesPageInner() {
   const dataCompanies = Array.isArray(remote) && remote.length > 0 ? remote : companies;
   // JBV: COMPANIES DATA WIRE-UP END
   const [sector, setSector] = useState<string>("All");
-  const chipOptions = useMemo(
-    () => sectors.filter((s) => !["Biotech", "Consumer", "Crypto", "Healthcare", "Insurance"].includes(String(s))),
-    []
-  );
+  const chipOptions = useMemo(() => {
+    const s = new Set<string>();
+    dataCompanies.forEach((c: any) => {
+      if (c.sector) s.add(String(c.sector));
+    });
+    const arr = Array.from(s).filter(
+      (val) => !["Biotech", "Consumer", "Crypto", "Healthcare", "Insurance"].includes(String(val))
+    );
+    return ["All", ...arr];
+  }, [dataCompanies]);
   const filtered = useMemo(() => {
     return sector === "All" ? dataCompanies : dataCompanies.filter(c => c.sector === sector);
   }, [sector, dataCompanies]);


### PR DESCRIPTION
## Summary
- avoid defaulting to a specific Airtable view so all records are fetched
- build company sector filters dynamically from the loaded data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(could not run: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68c59a6e352c8320b5b29e5fbce4e6c7