### PR TITLE
Revamp thesis page with interactive stack and scorecard

### DIFF
--- a/app/thesis/ThesisSections.tsx
+++ b/app/thesis/ThesisSections.tsx
@@ -1,0 +1,140 @@
+"use client";
+import React, { useRef, useState } from "react";
+import { motion, useInView, useReducedMotion } from "framer-motion";
+import { Source } from "./sources";
+
+export function PhaseList({ phases, selected, onSelect }: { phases: string[]; selected: number; onSelect: (i: number) => void }) {
+  const shouldReduceMotion = useReducedMotion();
+  return (
+    <div className="flex flex-wrap gap-2 mt-6">
+      {phases.map((_, i) => (
+        <motion.button
+          key={i}
+          aria-label={`Select Phase ${i + 1}`}
+          onClick={() => onSelect(i)}
+          className={`px-3 py-1 rounded-full border text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 ${
+            selected === i ? "bg-brand-100 text-brand-700 border-brand-300" : "bg-white text-slate-600"
+          }`}
+          animate={selected === i && !shouldReduceMotion ? { scale: [1.02, 1] } : {}}
+        >
+          Phase {i + 1}
+        </motion.button>
+      ))}
+    </div>
+  );
+}
+
+export function KPIBar({ label, value, note }: { label: string; value: number; note?: string }) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2 text-sm">
+        <span>{label}</span>
+        {note && (
+          <span className="cursor-help text-xs text-muted-foreground" title={note} aria-label={note}>
+            ⓘ
+          </span>
+        )}
+      </div>
+      <div className="h-2 w-full rounded-full bg-slate-200">
+        <div className="h-full rounded-full bg-brand-500" style={{ width: `${value}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export function Scorecard() {
+  const [scores, setScores] = useState([0, 0, 0, 0]);
+  const total = scores.reduce((a, b) => a + b, 0);
+  const label = total < 9 ? "iterate with focus" : "keep compounding";
+  return (
+    <div className="rounded-2xl shadow-lg shadow-soft p-6 md:p-8 bg-white">
+      <h3 className="text-lg font-semibold">Quick Scorecard (monthly, 0–3)</h3>
+      {['Thesis & speed', 'Distribution', 'Product loop', 'Economics'].map((name, idx) => (
+        <div key={name} className="mt-4">
+          <label className="flex justify-between text-sm mb-1" htmlFor={`score-${idx}`}>
+            <span>{name}</span>
+            <span>{scores[idx]}</span>
+          </label>
+          <input
+            id={`score-${idx}`}
+            aria-label={name}
+            type="range"
+            min={0}
+            max={3}
+            step={1}
+            value={scores[idx]}
+            onChange={(e) => {
+              const next = [...scores];
+              next[idx] = Number(e.target.value);
+              setScores(next);
+            }}
+            className="w-full accent-brand-500"
+          />
+        </div>
+      ))}
+      <div className="mt-6 text-sm font-medium">Total: {total} / 12</div>
+      <button
+        aria-label="scorecard action"
+        className="mt-2 rounded-md bg-brand-600 px-4 py-2 text-sm text-white"
+      >
+        {label}
+      </button>
+    </div>
+  );
+}
+
+export function SourcesDisclosure({ sources }: { sources: Source[] }) {
+  return (
+    <details className="mt-16 text-xs text-muted-foreground">
+      <summary className="cursor-pointer">Sources & further reading</summary>
+      <ul className="mt-2 space-y-1">
+        {sources.map((s) => (
+          <li key={s.url}>
+            <a
+              href={s.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-slate-900"
+            >
+              {s.title} — {s.publisher} ({s.yearOrDate})
+            </a>
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+}
+
+export function AdoptionDonut({ progress }: { progress: number }) {
+  const ref = useRef<SVGCircleElement | null>(null);
+  const isInView = useInView(ref, { once: true });
+  const shouldReduceMotion = useReducedMotion();
+  return (
+    <div className="sticky top-4 md:top-8 ml-auto flex flex-col items-center w-32 h-32">
+      <svg viewBox="0 0 100 100" className="w-full h-full">
+        <circle cx="50" cy="50" r="45" stroke="#e2e8f0" strokeWidth="10" fill="none" />
+        <motion.circle
+          ref={ref}
+          cx="50"
+          cy="50"
+          r="45"
+          stroke="url(#gradient)"
+          strokeWidth="10"
+          fill="none"
+          strokeLinecap="round"
+          initial={{ pathLength: 0 }}
+          animate={isInView && !shouldReduceMotion ? { pathLength: progress } : { pathLength: progress }}
+        />
+        <defs>
+          <linearGradient id="gradient" x1="0" x2="1" y1="1" y2="0">
+            <stop offset="0%" stopColor="#2f72ff" />
+            <stop offset="100%" stopColor="#8bb8ff" />
+          </linearGradient>
+        </defs>
+      </svg>
+      <p className="mt-2 text-center text-xs text-slate-600">
+        ≈ 8% → 16% adoption · Progress through the company-building stack
+      </p>
+    </div>
+  );
+}

--- a/app/thesis/page.tsx
+++ b/app/thesis/page.tsx
@@ -1,92 +1,160 @@
+"use client";
 export const dynamic = "force-dynamic";
-import React from "react";
-import StackEvolution from '@/components/thesis/StackEvolution';
+import React, { useRef, useState } from "react";
 import nextDynamic from "next/dynamic";
-const ThesisBackground = nextDynamic(() => import('@/components/thesis/bg/ThesisBackground'), { ssr: false });
-const Reveal = nextDynamic(() => import('@/components/anim/Reveal'), { ssr: false });
-import StartupStack from '@/components/thesis/StartupStack';
+import { motion } from "framer-motion";
+import { PhaseList, KPIBar, Scorecard, SourcesDisclosure, AdoptionDonut } from "./ThesisSections";
+import { sources } from "./sources";
+
+const ThesisBackground = nextDynamic(() => import("@/components/thesis/bg/ThesisBackground"), { ssr: false });
+
+interface Phase {
+  title: string;
+  why: string;
+  doNow: string;
+  benchmarks: string[];
+}
+
+const phases: Phase[] = [
+  {
+    title: "Phase 1 — Insight & Founders (Foundation)",
+    why: "Teams with a non-obvious insight and fast ship cadence compound advantage in every later layer.",
+    doNow: "30–100 customer interviews; weekly demo cadence; recruit 2–3 design partners.",
+    benchmarks: [
+      "time-to-first working demo ≤ 4–6 weeks",
+      "3–10 design partners"
+    ]
+  },
+  {
+    title: "Phase 2 — Access & Distribution (Go-to-Market Infrastructure)",
+    why: "One repeatable low-cost channel beats three mediocre ones.",
+    doNow: "Pick one primary channel; instrument activation; weekly funnel reviews.",
+    benchmarks: [
+      "CAC payback trending to category norms (SMB often < 12–18m; enterprise < 24m) and improving MoM"
+    ]
+  },
+  {
+    title: "Phase 3 — Product Engine & Habit (Models)",
+    why: "Durable usage via a core loop (flywheel/lock-in/network effects) is the engine of power laws.",
+    doNow: "Reduce setup friction; deliver one hero outcome; add 2–3 retention hooks (saved state, integrations, alerts).",
+    benchmarks: [
+      "Sean Ellis PMF signal ≥ 40% “very disappointed”",
+      "cohort retention curve flattening"
+    ]
+  },
+  {
+    title: "Phase 4 — Monetization, Moat & Scale (Applications)",
+    why: "With habit formed, pricing power and defensibility appear; then you scale responsibly.",
+    doNow: "Price testing; payback discipline; moat building (data advantage, integrations, ecosystem).",
+    benchmarks: [
+      "Positive payback at small scale",
+      "churn ↓; NRR ↑; margins expand"
+    ]
+  }
+];
 
 export default function ThesisPage() {
+  const [selected, setSelected] = useState(0);
+  const phaseRefs = useRef<Array<HTMLDivElement | null>>([]);
+
+  const handleSelect = (i: number) => {
+    setSelected(i);
+    phaseRefs.current[i]?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
   return (
     <main className="relative bg-white text-slate-900">
       <ThesisBackground />
-      {/* Futuristic light background */}
-      <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div className="absolute -top-32 -left-24 h-[40rem] w-[40rem] rounded-full blur-3xl opacity-40 bg-gradient-to-br from-sky-100 to-blue-200 animate-[float_24s_ease-in-out_infinite] motion-reduce:animate-none" />
-        <div className="absolute -bottom-24 -right-16 h-[36rem] w-[36rem] rounded-full blur-3xl opacity-30 bg-gradient-to-tr from-blue-50 to-cyan-200 animate-[float_30s_ease-in-out_infinite_reverse] motion-reduce:animate-none" />
-        <div className="absolute inset-0 opacity-30" style={{backgroundImage:"radial-gradient(rgba(15,23,42,0.06) 1px, transparent 1px), radial-gradient(rgba(15,23,42,0.04) 1px, transparent 1px)",backgroundSize:"26px 26px, 52px 52px",backgroundPosition:"0 0, 13px 13px",animation:"thesisDots 22s linear infinite"}} />
-        <style>{`@keyframes float { 0%,100% { transform: translateY(0) } 50% { transform: translateY(-16px) } } @keyframes thesisDots { from { transform: translateY(0) } to { transform: translateY(-26px) } }`}</style>
+      <div className="container-6xl py-16 relative">
+        <AdoptionDonut progress={(selected + 1) / phases.length} />
+        <h1 className="text-3xl md:text-5xl font-semibold tracking-tight max-w-4xl">
+          Startup Power Law Emergence: Company-Building Stack
+        </h1>
+        <PhaseList phases={phases.map(p => p.title)} selected={selected} onSelect={handleSelect} />
+        <div className="mt-10 grid grid-cols-1 lg:grid-cols-12 gap-8">
+          <div className="lg:col-span-7 space-y-8">
+            {phases.map((phase, idx) => (
+              <motion.div
+                key={phase.title}
+                ref={el => (phaseRefs.current[idx] = el)}
+                className={`rounded-2xl shadow-lg shadow-soft p-6 md:p-8 bg-white ${selected === idx ? 'ring-2 ring-brand-500' : ''}`}
+                initial={{ opacity: 0, y: 24 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ delay: idx * 0.1 }}
+              >
+                <h2 className="text-lg font-semibold">{phase.title}</h2>
+                <div className="mt-4 space-y-4 text-sm text-slate-600">
+                  <div>
+                    <h3 className="font-medium">Why it matters:</h3>
+                    <p>{phase.why}</p>
+                  </div>
+                  <div>
+                    <h3 className="font-medium">Do now:</h3>
+                    <p>{phase.doNow}</p>
+                  </div>
+                  <div>
+                    <h3 className="font-medium">Benchmarks:</h3>
+                    <ul className="list-disc pl-4">
+                      {phase.benchmarks.map(b => (
+                        <li key={b}>{b}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              </motion.div>
+            ))}
+          </div>
+          <div className="lg:col-span-5 space-y-8">
+            <motion.div
+              className="rounded-2xl shadow-lg shadow-soft p-6 md:p-8 bg-white"
+              initial={{ opacity: 0, y: 24 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: 0.2 }}
+            >
+              <h2 className="text-lg font-semibold">Stack Building Insight (AI):</h2>
+              <p className="mt-2 text-sm text-slate-600">
+                Power concentrates bottom-up. Semiconductors → infrastructure → models → applications. The binding constraint is increasingly physical (compute, power, supply chain). Winners scale infra reliably and translate it into compounding product loops.
+              </p>
+              <h3 className="mt-6 font-medium">AI Power Law Emergence: Tech Stack Evolution</h3>
+              <div className="mt-4 space-y-4 text-sm text-slate-600">
+                <div>
+                  <h4 className="font-medium">Phase 1: Semiconductors (2020–2025):</h4>
+                  <p>NVIDIA establishes AI accelerator dominance; capex wave begins.</p>
+                </div>
+                <div>
+                  <h4 className="font-medium">Phase 2: Infrastructure (2022–2026):</h4>
+                  <p>Data-center/network build accelerates; energy becomes a constraint.</p>
+                </div>
+                <div>
+                  <h4 className="font-medium">Phase 3: Models (2023–2027):</h4>
+                  <p>Foundation/domain models commercialize; tooling/ops mature.</p>
+                </div>
+                <div>
+                  <h4 className="font-medium">Phase 4: Applications (2025–2030):</h4>
+                  <p>Moats shift to workflow, distribution, and data; next 40× opportunities in verticals.</p>
+                </div>
+              </div>
+              <div className="mt-6 space-y-3">
+                <KPIBar label="Phase 1" value={100} note="2020–2025" />
+                <KPIBar label="Phase 2" value={60} note="2022–2026" />
+                <KPIBar label="Phase 3" value={40} note="2023–2027" />
+                <KPIBar label="Phase 4" value={20} note="2025–2030" />
+              </div>
+            </motion.div>
+            <motion.div
+              initial={{ opacity: 0, y: 24 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: 0.3 }}
+            >
+              <Scorecard />
+            </motion.div>
+          </div>
+        </div>
+        <SourcesDisclosure sources={sources} />
       </div>
-      {/* Animated dot matrix background */}
-      <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div className="absolute inset-0 opacity-20" style={{
-          backgroundImage:
-            "radial-gradient(rgba(255,255,255,0.4) 1px, transparent 1px), radial-gradient(rgba(255,255,255,0.15) 1px, transparent 1px)",
-          backgroundSize: "28px 28px, 56px 56px",
-          backgroundPosition: "0 0, 14px 14px",
-          animation: "thesisDots 18s linear infinite"
-        }} />
-        <style>{`@keyframes thesisDots { from { transform: translateY(0) } to { transform: translateY(-28px) } }`}</style>
-      </div>
-      <section className="relative z-10 min-h-[56vh] flex items-center">
-        <div className="container-6xl py-20">
-          <Reveal>
-            <h1 className="text-4xl md:text-6xl font-semibold tracking-tight">Our Thesis</h1>
-          </Reveal>
-          <Reveal delay={0.08}><p className="mt-4 max-w-2xl text-slate-600 text-lg">
-            We partner with founders from seed through early stages across AI, enterprise, fintech, consumer, and more.
-          </p></Reveal>
-        </div>
-      </section>
-      <section id="build-stack" className="scroll-mt-24"><StartupStack/></section>
-      <section id="stack" className="scroll-mt-24"><StackEvolution/></section>
-      <section className="relative z-10 border-t border-slate-200/60 bg-white/70 backdrop-blur">
-        <div className="container-6xl py-16">
-          <div className="grid md:grid-cols-3 gap-10 items-start">
-            <div className="md:col-span-1">
-              <Reveal><h2 className="text-xl font-semibold">What we do</h2></Reveal>
-            </div>
-            <div className="md:col-span-2">
-              <Reveal delay={0.06}><p className="text-slate-600 leading-7 max-w-2xl">
-                We partner with founders from seed through early stages across AI, enterprise, fintech, consumer, and more.
-                This starter focuses on layout, navigation, and animation patterns—not content.
-              </p></Reveal>
-            </div>
-          </div>
-        </div>
-      </section>
-      <section className="relative z-10 border-t border-slate-200/60 bg-gradient-to-b from-white to-sky-50/40">
-        <div className="container-6xl py-16">
-          <div className="grid md:grid-cols-3 gap-10 items-start">
-            <div className="md:col-span-1">
-              <Reveal><h2 className="text-xl font-semibold">Approach</h2></Reveal>
-            </div>
-            <div className="md:col-span-2">
-              <Reveal delay={0.06}><p className="text-slate-600 leading-7 max-w-2xl">
-                We move early, back exceptional teams, and help them compound advantages—product, go-to-market, and talent—
-                while staying focused on durable value creation.
-              </p></Reveal>
-            </div>
-          </div>
-        </div>
-      </section>
-      <section className="relative z-10 border-t border-slate-200/60 bg-white">
-        <div className="container-6xl py-16">
-          <div className="grid md:grid-cols-3 gap-10 items-start">
-            <div className="md:col-span-1">
-              <Reveal><h2 className="text-xl font-semibold">Focus Areas</h2></Reveal>
-            </div>
-            <div className="md:col-span-2">
-              <Reveal delay={0.06}><ul className="grid sm:grid-cols-2 gap-3 text-slate-600">
-                <li className="rounded-xl border border-slate-200 bg-sky-50/60 px-4 py-3">AI & Applied AI</li>
-                <li className="rounded-xl border border-slate-200 bg-sky-50/60 px-4 py-3">Enterprise Software</li>
-                <li className="rounded-xl border border-slate-200 bg-sky-50/60 px-4 py-3">Fintech & Infrastructure</li>
-                <li className="rounded-xl border border-slate-200 bg-sky-50/60 px-4 py-3">Consumer & Community</li>
-              </ul></Reveal>
-            </div>
-          </div>
-        </div>
-      </section>
     </main>
   );
 }

--- a/app/thesis/sources.ts
+++ b/app/thesis/sources.ts
@@ -1,0 +1,17 @@
+export interface Source {
+  title: string;
+  publisher: string;
+  yearOrDate: string;
+  url: string;
+}
+
+export const sources: Source[] = [
+  { title: "Sean Ellis PMF Survey (40% signal)", publisher: "pmfsurvey.com", yearOrDate: "ongoing", url: "https://pmfsurvey.com/" },
+  { title: "How to measure PMF (explainers)", publisher: "Prelaunch & case studies", yearOrDate: "2023–2025", url: "https://prelaunch.com/blog/sean-ellis-test" },
+  { title: "Cloud metrics & CAC payback", publisher: "Bessemer Venture Partners", yearOrDate: "evergreen", url: "https://www.bvp.com/atlas/cloud-computing-metrics/" },
+  { title: "SaaS CAC Payback Benchmarks", publisher: "First Page Sage", yearOrDate: "2024–2025", url: "https://firstpagesage.com/reports/saas-cac-payback-benchmarks/" },
+  { title: "Full-stack AI constraints", publisher: "CSIS", yearOrDate: "2025", url: "https://www.csis.org/analysis/securing-full-stack-us-leadership-ai" },
+  { title: "Semiconductor & data-center investment wave", publisher: "McKinsey / U.S. data-center build reporting", yearOrDate: "2024–2025", url: "https://www.mckinsey.com/~/media/mckinsey/industries/semiconductors/our%20insights/mckinsey%20on%20semiconductors%202024/mck_semiconductors_2024_webpdf.pdf" },
+  { title: "AI data-center build (news context)", publisher: "Reuters", yearOrDate: "2025", url: "https://www.reuters.com/business/us-data-center-build-hits-record-ai-demand-surges-bank-america-institute-says-2025-09-10/" },
+  { title: "NVIDIA AI accelerator market share (analyst est.)", publisher: "Yahoo Finance (analyst note)", yearOrDate: "2025", url: "https://finance.yahoo.com/news/nvidia-dominates-ai-chips-analyst-143411443.html" }
+];


### PR DESCRIPTION
## Summary
- overhaul Thesis page with company-building phases and AI stack insight
- add local components for phase navigation, adoption donut, KPI bars, and scorecard
- include sources disclosure for further reading

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_b_68c5a455e1a483208850007dd34db73b