### PR TITLE
Revamp thesis page with animated frameworks

### DIFF
--- a/app/thesis/page.tsx
+++ b/app/thesis/page.tsx
@@ -1,161 +1,22 @@
-"use client";
+import ThesisHero from "@/components/thesis/ThesisHero";
+import StackPhases from "@/components/thesis/StackPhases";
+import JourneyTracker from "@/components/thesis/JourneyTracker";
+import AITimeline from "@/components/thesis/AITimeline";
+import Glossary from "@/components/thesis/Glossary";
+import PovClosing from "@/components/thesis/PovClosing";
+
 export const dynamic = "force-dynamic";
-import React, { useRef, useState } from "react";
-import nextDynamic from "next/dynamic";
-import { motion } from "framer-motion";
-import { PhaseList, KPIBar, Scorecard, SourcesDisclosure, AdoptionDonut } from "./ThesisSections";
-import { sources } from "./sources";
-
-const ThesisBackground = nextDynamic(() => import("@/components/thesis/bg/ThesisBackground"), { ssr: false });
-
-interface Phase {
-  title: string;
-  why: string;
-  doNow: string;
-  benchmarks: string[];
-}
-
-const phases: Phase[] = [
-  {
-    title: "Phase 1 — Insight & Founders (Foundation)",
-    why: "Teams with a non-obvious insight and fast ship cadence compound advantage in every later layer.",
-    doNow: "30–100 customer interviews; weekly demo cadence; recruit 2–3 design partners.",
-    benchmarks: [
-      "time-to-first working demo ≤ 4–6 weeks",
-      "3–10 design partners"
-    ]
-  },
-  {
-    title: "Phase 2 — Access & Distribution (Go-to-Market Infrastructure)",
-    why: "One repeatable low-cost channel beats three mediocre ones.",
-    doNow: "Pick one primary channel; instrument activation; weekly funnel reviews.",
-    benchmarks: [
-      "CAC payback trending to category norms (SMB often < 12–18m; enterprise < 24m) and improving MoM"
-    ]
-  },
-  {
-    title: "Phase 3 — Product Engine & Habit (Models)",
-    why: "Durable usage via a core loop (flywheel/lock-in/network effects) is the engine of power laws.",
-    doNow: "Reduce setup friction; deliver one hero outcome; add 2–3 retention hooks (saved state, integrations, alerts).",
-    benchmarks: [
-      "Sean Ellis PMF signal ≥ 40% “very disappointed”",
-      "cohort retention curve flattening"
-    ]
-  },
-  {
-    title: "Phase 4 — Monetization, Moat & Scale (Applications)",
-    why: "With habit formed, pricing power and defensibility appear; then you scale responsibly.",
-    doNow: "Price testing; payback discipline; moat building (data advantage, integrations, ecosystem).",
-    benchmarks: [
-      "Positive payback at small scale",
-      "churn ↓; NRR ↑; margins expand"
-    ]
-  }
-];
 
 export default function ThesisPage() {
-  const [selected, setSelected] = useState(0);
-  const phaseRefs = useRef<Array<HTMLDivElement | null>>([]);
-
-  const handleSelect = (i: number) => {
-    setSelected(i);
-    phaseRefs.current[i]?.scrollIntoView({ behavior: "smooth", block: "start" });
-  };
-
   return (
-    <main className="relative bg-white text-slate-900">
-      <ThesisBackground />
-      <div className="container-6xl py-16 relative">
-        <AdoptionDonut progress={(selected + 1) / phases.length} />
-        <h1 className="text-3xl md:text-5xl font-semibold tracking-tight max-w-4xl">
-          Startup Power Law Emergence: Company-Building Stack
-        </h1>
-        <PhaseList phases={phases.map(p => p.title)} selected={selected} onSelect={handleSelect} />
-        <div className="mt-10 grid grid-cols-1 lg:grid-cols-12 gap-8">
-          <div className="lg:col-span-7 space-y-8">
-            {phases.map((phase, idx) => (
-              <motion.div
-                key={phase.title}
-                ref={(el) => {
-                  phaseRefs.current[idx] = el;
-                }}
-                className={`rounded-2xl shadow-lg shadow-soft p-6 md:p-8 bg-white ${selected === idx ? 'ring-2 ring-brand-500' : ''}`}
-                initial={{ opacity: 0, y: 24 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                transition={{ delay: idx * 0.1 }}
-              >
-                <h2 className="text-lg font-semibold">{phase.title}</h2>
-                <div className="mt-4 space-y-4 text-sm text-slate-600">
-                  <div>
-                    <h3 className="font-medium">Why it matters:</h3>
-                    <p>{phase.why}</p>
-                  </div>
-                  <div>
-                    <h3 className="font-medium">Do now:</h3>
-                    <p>{phase.doNow}</p>
-                  </div>
-                  <div>
-                    <h3 className="font-medium">Benchmarks:</h3>
-                    <ul className="list-disc pl-4">
-                      {phase.benchmarks.map(b => (
-                        <li key={b}>{b}</li>
-                      ))}
-                    </ul>
-                  </div>
-                </div>
-              </motion.div>
-            ))}
-          </div>
-          <div className="lg:col-span-5 space-y-8">
-            <motion.div
-              className="rounded-2xl shadow-lg shadow-soft p-6 md:p-8 bg-white"
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ delay: 0.2 }}
-            >
-              <h2 className="text-lg font-semibold">Stack Building Insight (AI):</h2>
-              <p className="mt-2 text-sm text-slate-600">
-                Power concentrates bottom-up. Semiconductors → infrastructure → models → applications. The binding constraint is increasingly physical (compute, power, supply chain). Winners scale infra reliably and translate it into compounding product loops.
-              </p>
-              <h3 className="mt-6 font-medium">AI Power Law Emergence: Tech Stack Evolution</h3>
-              <div className="mt-4 space-y-4 text-sm text-slate-600">
-                <div>
-                  <h4 className="font-medium">Phase 1: Semiconductors (2020–2025):</h4>
-                  <p>NVIDIA establishes AI accelerator dominance; capex wave begins.</p>
-                </div>
-                <div>
-                  <h4 className="font-medium">Phase 2: Infrastructure (2022–2026):</h4>
-                  <p>Data-center/network build accelerates; energy becomes a constraint.</p>
-                </div>
-                <div>
-                  <h4 className="font-medium">Phase 3: Models (2023–2027):</h4>
-                  <p>Foundation/domain models commercialize; tooling/ops mature.</p>
-                </div>
-                <div>
-                  <h4 className="font-medium">Phase 4: Applications (2025–2030):</h4>
-                  <p>Moats shift to workflow, distribution, and data; next 40× opportunities in verticals.</p>
-                </div>
-              </div>
-              <div className="mt-6 space-y-3">
-                <KPIBar label="Phase 1" value={100} note="2020–2025" />
-                <KPIBar label="Phase 2" value={60} note="2022–2026" />
-                <KPIBar label="Phase 3" value={40} note="2023–2027" />
-                <KPIBar label="Phase 4" value={20} note="2025–2030" />
-              </div>
-            </motion.div>
-            <motion.div
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ delay: 0.3 }}
-            >
-              <Scorecard />
-            </motion.div>
-          </div>
-        </div>
-        <SourcesDisclosure sources={sources} />
+    <main className="bg-sky-50 pb-24 pt-16 text-slate-900">
+      <div className="container-6xl space-y-24">
+        <ThesisHero />
+        <StackPhases />
+        <JourneyTracker />
+        <AITimeline />
+        <Glossary />
+        <PovClosing />
       </div>
     </main>
   );

--- a/components/thesis/AITimeline.tsx
+++ b/components/thesis/AITimeline.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  motion,
+  useMotionValueEvent,
+  useReducedMotion,
+  useScroll,
+  useSpring,
+  useTransform
+} from "framer-motion";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+const stages = [
+  {
+    id: "semiconductors",
+    title: "Semiconductors",
+    range: "2020–2025",
+    description: "AI accelerators concentrate compute.",
+    constraint: "supply and advanced packaging",
+    constraintDetail: "Allocation is tight and packaging is specialized—plan for long lead times and partners.",
+    builderKey: "semis"
+  },
+  {
+    id: "infrastructure",
+    title: "Infrastructure",
+    range: "2022–2026",
+    description: "Data-center/network build accelerates.",
+    constraint: "energy and reliability",
+    constraintDetail: "Energy availability and uptime discipline define your cost per job—design for resilience.",
+    builderKey: "semis"
+  },
+  {
+    id: "models",
+    title: "Models",
+    range: "2023–2027",
+    description: "Foundation/domain models commercialize; tooling/ops mature.",
+    constraint: "Inference cost & latency",
+    constraintDetail: "Latency budgets and inference costs shape gross margins—measure, cache, retrieve smartly.",
+    builderKey: "models"
+  },
+  {
+    id: "applications",
+    title: "Applications",
+    range: "2025–2030",
+    description: "Moats shift to workflow, distribution, and data; verticals compound.",
+    constraint: "Switching costs & embeddedness",
+    constraintDetail: "Being irreplaceable requires deep workflow ownership, distribution, and data feedback loops.",
+    builderKey: "apps"
+  }
+] as const;
+
+const builderNotes: Record<string, string> = {
+  semis: "Partner with reliable providers; design for cost per token/job.",
+  models: "Focus on task performance and latency budgets; evaluate retrievability and evals.",
+  apps: "Own workflow and distribution; build data advantage; embed where work happens."
+};
+
+export default function AITimeline() {
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const prefersReducedMotion = useReducedMotion();
+  const { scrollYProgress } = useScroll({
+    target: trackRef,
+    offset: ["start end", "end start"]
+  });
+  const x = useTransform(scrollYProgress, [0, 1], ["0%", "-45%"]); // slide cards horizontally
+  const lineProgress = useSpring(scrollYProgress, { stiffness: 120, damping: 24, restDelta: 0.001 });
+  const [activeStage, setActiveStage] = useState(0);
+
+  useMotionValueEvent(scrollYProgress, "change", (value) => {
+    if (prefersReducedMotion) {
+      return;
+    }
+    const clamped = Math.max(0, Math.min(0.999, value));
+    const next = Math.min(stages.length - 1, Math.floor(clamped * stages.length));
+    setActiveStage((prev) => (prev === next ? prev : next));
+  });
+
+  useEffect(() => {
+    if (prefersReducedMotion) {
+      setActiveStage(stages.length - 1);
+    }
+  }, [prefersReducedMotion]);
+
+  const activeBuilderNote = useMemo(() => {
+    const key = stages[activeStage]?.builderKey ?? "semis";
+    return builderNotes[key];
+  }, [activeStage]);
+
+  return (
+    <TooltipProvider delayDuration={120}>
+      <section className="mx-auto mt-24 max-w-6xl" aria-labelledby="ai-timeline-heading">
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,1fr)] lg:items-start">
+          <div className="relative overflow-hidden rounded-3xl bg-white/90 px-6 py-10 shadow-soft backdrop-blur" ref={trackRef}>
+            <h2 id="ai-timeline-heading" className="text-2xl font-semibold text-slate-900">
+              AI Power Law Stack
+            </h2>
+            <p className="mt-3 max-w-xl text-sm text-slate-600">
+              Scroll to see how semiconductors → infrastructure → models → applications compound—and where constraints bite.
+            </p>
+            <div className="relative mt-8 h-[22rem] overflow-hidden">
+              <motion.div
+                className="absolute left-0 top-1/2 h-[2px] w-full -translate-y-1/2 bg-sky-100"
+                style={{ scaleX: prefersReducedMotion ? 1 : lineProgress, originX: 0 }}
+                aria-hidden="true"
+              />
+              <motion.div
+                className="flex h-full items-center gap-8"
+                style={prefersReducedMotion ? undefined : { x }}
+              >
+                {stages.map((stage, index) => {
+                  const isActive = prefersReducedMotion ? index === stages.length - 1 : activeStage === index;
+                  return (
+                    <motion.article
+                      key={stage.id}
+                      initial={{ opacity: 0, y: 24 }}
+                      whileInView={{ opacity: 1, y: 0 }}
+                      viewport={{ once: true, amount: 0.5 }}
+                      transition={{ type: "spring", stiffness: 120, damping: 18 }}
+                      className={`relative min-w-[260px] max-w-[280px] rounded-3xl border px-5 py-6 shadow-soft transition-transform ${isActive ? "border-sky-400 bg-sky-50" : "border-slate-200 bg-white/70"}`}
+                    >
+                      <div className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+                        {stage.range}
+                      </div>
+                      <h3 className="mt-2 text-lg font-semibold text-slate-900">{stage.title}</h3>
+                      <p className="mt-2 text-sm leading-relaxed text-slate-600">{stage.description}</p>
+                      <div className="mt-4 flex items-center gap-2">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span
+                              className="inline-flex cursor-default items-center gap-2 rounded-full border border-sky-300 bg-white/80 px-3 py-1 text-xs font-medium text-sky-700"
+                              role="listitem"
+                            >
+                              Constraint · {stage.constraint}
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p className="text-xs leading-relaxed text-slate-600">{stage.constraintDetail}</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </div>
+                      <div className="mt-4 h-2 overflow-hidden rounded-full bg-slate-200">
+                        <motion.div
+                          className="h-full bg-gradient-to-r from-sky-400 to-sky-600"
+                          initial={{ width: 0 }}
+                          whileInView={{ width: "100%" }}
+                          viewport={{ once: true }}
+                          transition={{ type: "spring", stiffness: 120, damping: 20, delay: index * 0.05 }}
+                        />
+                      </div>
+                      <div className="absolute -bottom-3 left-1/2 h-3 w-3 -translate-x-1/2 rounded-full border border-sky-300 bg-white" aria-hidden="true" />
+                    </motion.article>
+                  );
+                })}
+              </motion.div>
+            </div>
+          </div>
+          <aside className="sticky top-32 rounded-3xl bg-sky-900/90 p-8 text-slate-100 shadow-soft">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-sky-200">
+              What this means for builders today
+            </p>
+            <motion.p
+              key={activeBuilderNote}
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ type: "spring", stiffness: 120, damping: 18 }}
+              className="mt-4 text-base leading-relaxed text-slate-100"
+            >
+              {activeBuilderNote}
+            </motion.p>
+            <ul className="mt-6 space-y-4 text-sm text-slate-200">
+              {stages.map((stage, index) => (
+                <li key={stage.id} className={`transition-opacity ${index === activeStage ? "opacity-100" : "opacity-50"}`}>
+                  <span className="block text-xs font-semibold uppercase tracking-[0.24em] text-sky-300">
+                    {stage.title}
+                  </span>
+                  <span className="mt-1 block text-sm text-slate-100">{stage.description}</span>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        </div>
+      </section>
+    </TooltipProvider>
+  );
+}

--- a/components/thesis/Glossary.tsx
+++ b/components/thesis/Glossary.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+const glossary = [
+  {
+    term: "CAC Payback",
+    definition: "Months to recover acquisition spend from gross margin.",
+    why: "Faster = more shots on goal."
+  },
+  {
+    term: "PMF",
+    definition: "Users would be “very disappointed” without you (≥ 40%)."
+  },
+  {
+    term: "Cohort Retention",
+    definition: "Curve flattening = habit formation."
+  },
+  {
+    term: "NRR",
+    definition: "Expansion vs churn; >100% shows compounding value."
+  },
+  {
+    term: "Moat",
+    definition: "Durable advantage—data, network, workflows, ecosystem."
+  }
+] as const;
+
+export default function Glossary() {
+  const prefersReducedMotion = useReducedMotion();
+  const headingMotion = prefersReducedMotion
+    ? { initial: { opacity: 1, y: 0 }, whileInView: { opacity: 1, y: 0 } }
+    : { initial: { opacity: 0, y: 24 }, whileInView: { opacity: 1, y: 0 } };
+  return (
+    <section className="mx-auto mt-24 max-w-6xl rounded-3xl bg-white/90 p-8 shadow-soft backdrop-blur" aria-labelledby="glossary-heading">
+      <motion.div
+        {...headingMotion}
+        viewport={{ once: true, amount: 0.3 }}
+        transition={{ type: "spring", stiffness: 120, damping: 18 }}
+      >
+        <h2 id="glossary-heading" className="text-2xl font-semibold text-slate-900">
+          Mini-Glossary
+        </h2>
+        <p className="mt-3 max-w-2xl text-sm text-slate-600">
+          Crisp definitions for the shorthand we use with founders—tap a chip to refresh the context.
+        </p>
+      </motion.div>
+      <div className="mt-6 flex flex-wrap gap-3">
+        {glossary.map((item, index) => (
+          <Popover key={item.term}>
+            <PopoverTrigger asChild>
+              <motion.button
+                type="button"
+                initial={prefersReducedMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: 12 }}
+                whileInView={prefersReducedMotion ? { opacity: 1, y: 0 } : { opacity: 1, y: 0 }}
+                viewport={{ once: true, amount: 0.3 }}
+                transition={{ type: "spring", stiffness: 120, damping: 18, delay: index * 0.05 }}
+                className="rounded-full border border-sky-300 bg-white/80 px-4 py-2 text-sm font-medium text-sky-700 shadow-sm transition-colors hover:border-sky-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+              >
+                {item.term}
+              </motion.button>
+            </PopoverTrigger>
+            <PopoverContent align="start" className="max-w-xs">
+              <p className="text-sm font-semibold text-slate-900">{item.term}</p>
+              <p className="mt-2 text-sm text-slate-600">{item.definition}</p>
+              {item.why && (
+                <>
+                  <p className="mt-3 text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">Why it matters</p>
+                  <p className="mt-1 text-sm text-slate-600">{item.why}</p>
+                </>
+              )}
+            </PopoverContent>
+          </Popover>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/thesis/JourneyTracker.tsx
+++ b/components/thesis/JourneyTracker.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import {
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+  ResponsiveContainer
+} from "recharts";
+
+const phases = [
+  { id: "p1", label: "Phase 1", subtitle: "Insight & Founders" },
+  { id: "p2", label: "Phase 2", subtitle: "Access & Distribution" },
+  { id: "p3", label: "Phase 3", subtitle: "Product Engine & Habit" },
+  { id: "p4", label: "Phase 4", subtitle: "Monetization & Scale" }
+] as const;
+
+const focusAreas = [
+  { key: "Insight", summary: "Insight compounds when truth-seeking conversations stay close to the problem." },
+  { key: "Distribution", summary: "Distribution power shows up when one channel predictably fills the top of funnel." },
+  { key: "Product Loop", summary: "Early traction is habit-forming when cohort curves flatten." },
+  { key: "Economics", summary: "Pricing power appears after habits hold and payback discipline kicks in." }
+] as const;
+
+const phaseDefaults: Record<(typeof phases)[number]["id"], Record<string, number>> = {
+  p1: { Insight: 4.5, Distribution: 2.2, "Product Loop": 1.4, Economics: 1 },
+  p2: { Insight: 3.4, Distribution: 4.3, "Product Loop": 2.4, Economics: 1.3 },
+  p3: { Insight: 2.6, Distribution: 3.4, "Product Loop": 4.6, Economics: 2.2 },
+  p4: { Insight: 2, Distribution: 3, "Product Loop": 3.8, Economics: 4.8 }
+};
+
+const chartConfig = {
+  stroke: "#0ea5e9",
+  fill: "rgba(14,165,233,0.35)",
+  grid: "rgba(148,163,184,0.25)",
+  text: "#0f172a"
+};
+
+export default function JourneyTracker() {
+  const [phase, setPhase] = useState<(typeof phases)[number]["id"]>("p1");
+  const [focus, setFocus] = useState<Set<string>>(() => new Set(["Insight"]));
+  const prefersReducedMotion = useReducedMotion();
+
+  const chartData = useMemo(() => {
+    const base = phaseDefaults[phase];
+    return focusAreas.map((area) => {
+      const boost = focus.has(area.key) ? 0.9 : 0;
+      const value = Math.min(5, base[area.key] + boost);
+      return {
+        category: area.key,
+        value
+      };
+    });
+  }, [focus, phase]);
+
+  const highlightedSummaries = useMemo(() => {
+    return focusAreas.map((area) => ({
+      key: area.key,
+      summary: area.summary,
+      active: focus.has(area.key)
+    }));
+  }, [focus]);
+
+  return (
+    <section className="mx-auto mt-24 max-w-6xl rounded-3xl bg-white/90 p-8 shadow-soft backdrop-blur" aria-labelledby="journey-tracker-heading">
+      <div className="flex flex-col gap-10 lg:flex-row">
+        <div className="lg:w-72">
+          <h2 id="journey-tracker-heading" className="text-2xl font-semibold text-slate-900">
+            Journey Tracker
+          </h2>
+          <p className="mt-3 text-sm text-slate-600">
+            Where are you leaning in today? Select a phase and the loop you are strengthening—the radar shows which slice is lit up.
+          </p>
+          <div className="mt-6 space-y-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Phase</p>
+              <div className="mt-3 grid grid-cols-2 gap-2" role="radiogroup" aria-label="Select current phase">
+                {phases.map((item) => {
+                  const isActive = phase === item.id;
+                  return (
+                    <button
+                      key={item.id}
+                      type="button"
+                      role="radio"
+                      aria-checked={isActive}
+                      onClick={() => setPhase(item.id)}
+                      className={`rounded-2xl border px-4 py-3 text-left text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 ${isActive ? "border-sky-400 bg-sky-50 text-sky-700" : "border-slate-200 bg-white/70 text-slate-600 hover:border-slate-300"}`}
+                    >
+                      <span className="block font-semibold">{item.label}</span>
+                      <span className="mt-0.5 block text-xs text-slate-500">{item.subtitle}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Focus tags</p>
+              <div className="mt-3 flex flex-wrap gap-2" role="group" aria-label="Select focus areas">
+                {focusAreas.map((area) => {
+                  const isActive = focus.has(area.key);
+                  return (
+                    <button
+                      key={area.key}
+                      type="button"
+                      aria-pressed={isActive}
+                      onClick={() => {
+                        setFocus((prev) => {
+                          const next = new Set(prev);
+                          if (next.has(area.key)) {
+                            next.delete(area.key);
+                          } else {
+                            next.add(area.key);
+                          }
+                          return next;
+                        });
+                      }}
+                      className={`rounded-full border px-4 py-2 text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 ${isActive ? "border-sky-400 bg-sky-100 text-sky-700" : "border-slate-200 bg-white/70 text-slate-600 hover:border-slate-300"}`}
+                    >
+                      {area.key}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="flex-1">
+          <div className="h-72 w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <RadarChart data={chartData} cx="50%" cy="50%" outerRadius="75%">
+                <PolarGrid stroke={chartConfig.grid} strokeWidth={1} />
+                <PolarAngleAxis dataKey="category" tick={{ fill: chartConfig.text, fontSize: 12 }} />
+                <PolarRadiusAxis domain={[0, 5]} tickCount={6} axisLine={false} tick={false} />
+                <Radar
+                  dataKey="value"
+                  stroke={chartConfig.stroke}
+                  fill={chartConfig.fill}
+                  fillOpacity={prefersReducedMotion ? 0.45 : 0.55}
+                  isAnimationActive={!prefersReducedMotion}
+                />
+              </RadarChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="mt-6 grid gap-4 sm:grid-cols-2">
+            {highlightedSummaries.map((item) => (
+              <motion.div
+                key={item.key}
+                initial={{ opacity: 0, y: 12 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, amount: 0.4 }}
+                transition={{ type: "spring", stiffness: 120, damping: 18 }}
+                className={`rounded-2xl border px-4 py-3 text-sm ${item.active ? "border-sky-400 bg-sky-50 text-sky-800" : "border-slate-200 bg-white text-slate-600"}`}
+              >
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">{item.key}</p>
+                <p className="mt-1 text-sm leading-relaxed">{item.summary}</p>
+              </motion.div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/thesis/PovClosing.tsx
+++ b/components/thesis/PovClosing.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Link from "next/link";
+import { motion, useReducedMotion } from "framer-motion";
+
+const bullets = [
+  "We underwrite loops, not just features.",
+  "We prefer one repeatable channel over noisy multi-channel hacks.",
+  "We look for evidence that habits precede pricing power."
+] as const;
+
+export default function PovClosing() {
+  const prefersReducedMotion = useReducedMotion();
+  const listMotion = prefersReducedMotion
+    ? { initial: { opacity: 1, y: 0 }, whileInView: { opacity: 1, y: 0 } }
+    : { initial: { opacity: 0, y: 18 }, whileInView: { opacity: 1, y: 0 } };
+
+  return (
+    <section className="mx-auto mt-24 max-w-6xl overflow-hidden rounded-3xl bg-gradient-to-r from-sky-700 via-sky-800 to-sky-900 px-8 py-12 text-slate-100 shadow-soft" aria-labelledby="pov-heading">
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)] lg:items-center">
+        <div>
+          <h2 id="pov-heading" className="text-3xl font-semibold leading-tight">
+            How we invest against these loops
+          </h2>
+          <p className="mt-3 text-sm text-sky-100/80">
+            Two frameworks, one POV: compound loops turn insight into durable economics.
+          </p>
+          <motion.ul
+            {...listMotion}
+            viewport={{ once: true, amount: 0.4 }}
+            transition={{ type: "spring", stiffness: 120, damping: 18 }}
+            className="mt-6 space-y-3 text-sm"
+          >
+            {bullets.map((item) => (
+              <li key={item} className="flex items-start gap-3">
+                <span className="mt-1 inline-flex h-2.5 w-2.5 flex-none rounded-full bg-sky-300" aria-hidden="true" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </motion.ul>
+        </div>
+        <motion.div
+          initial={prefersReducedMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: 18 }}
+          whileInView={prefersReducedMotion ? { opacity: 1, y: 0 } : { opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.4 }}
+          transition={{ type: "spring", stiffness: 120, damping: 18 }}
+          className="rounded-3xl border border-white/20 bg-white/10 p-6 backdrop-blur"
+        >
+          <p className="text-sm text-slate-100/80">
+            Building something that compounds these loops? We want to hear from you.
+          </p>
+          <Link
+            href="mailto:jb@jbv.com?subject=JBV%20Thesis%20%7C%20Share%20your%20build"
+            className="mt-4 inline-flex items-center justify-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-sky-800 transition hover:translate-y-0.5 hover:bg-sky-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+          >
+            Share your build with us
+          </Link>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/components/thesis/StackPhases.tsx
+++ b/components/thesis/StackPhases.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useMemo, useRef } from "react";
+import { motion, useReducedMotion, useScroll, useSpring } from "framer-motion";
+import { Lightbulb, Megaphone, Repeat, Castle } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+const phases = [
+  {
+    id: "p1",
+    title: "Phase 1 — Insight & Founders (Foundation)",
+    icon: Lightbulb,
+    why: "Earned, non-obvious insight + fast shipping compounds advantage later.",
+    doNow: [
+      "30–100 customer interviews",
+      "weekly demos",
+      "2–3 design partners"
+    ],
+    benchmarks: [
+      "Time-to-first working demo ≤ 4–6 weeks",
+      "3–10 design partners"
+    ],
+    accent: "border-sky-200",
+    gradient: "from-sky-100/70 via-white/80 to-transparent"
+  },
+  {
+    id: "p2",
+    title: "Phase 2 — Access & Distribution (Go-to-Market)",
+    icon: Megaphone,
+    why: "One repeatable low-cost channel beats three mediocre ones.",
+    doNow: [
+      "Pick a primary channel",
+      "instrument activation",
+      "weekly funnel reviews"
+    ],
+    benchmarks: [
+      "CAC payback trending to norms (SMB often < 12–18m; enterprise < 24m) and improving MoM"
+    ],
+    accent: "border-sky-300",
+    gradient: "from-sky-200/70 via-white/80 to-transparent"
+  },
+  {
+    id: "p3",
+    title: "Phase 3 — Product Engine & Habit (Loops)",
+    icon: Repeat,
+    why: "Durable usage via a core loop (flywheel/lock-in/network effects) is the engine of power laws.",
+    doNow: [
+      "Reduce setup friction",
+      "deliver one hero outcome",
+      "add 2–3 retention hooks"
+    ],
+    benchmarks: [
+      "Sean Ellis PMF ≥ 40% “very disappointed”",
+      "cohort retention curve flattening"
+    ],
+    accent: "border-sky-400",
+    gradient: "from-sky-300/70 via-white/70 to-transparent"
+  },
+  {
+    id: "p4",
+    title: "Phase 4 — Monetization, Moat & Scale (Applications)",
+    icon: Castle,
+    why: "With habit formed, pricing power and defensibility appear; then you scale responsibly.",
+    doNow: [
+      "Price testing",
+      "payback discipline",
+      "moat building (data, integrations, ecosystem)"
+    ],
+    benchmarks: [
+      "Positive payback at small scale",
+      "Churn ↓; NRR ↑; margins expand"
+    ],
+    accent: "border-sky-500",
+    gradient: "from-sky-400/60 via-white/70 to-transparent"
+  }
+] as const;
+
+export default function StackPhases() {
+  const sectionRef = useRef<HTMLDivElement | null>(null);
+  const prefersReducedMotion = useReducedMotion();
+  const { scrollYProgress } = useScroll({
+    target: sectionRef,
+    offset: ["start end", "end start"]
+  });
+  const progress = useSpring(scrollYProgress, {
+    stiffness: 160,
+    damping: 20,
+    restDelta: 0.001
+  });
+
+  const variants = useMemo(
+    () => ({
+      initial: prefersReducedMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: 18 },
+      animate: prefersReducedMotion ? { opacity: 1, y: 0 } : { opacity: 1, y: 0 }
+    }),
+    [prefersReducedMotion]
+  );
+
+  return (
+    <TooltipProvider delayDuration={120}>
+      <section ref={sectionRef} className="relative" aria-labelledby="company-stack-heading">
+        <div className="mx-auto flex max-w-6xl flex-col gap-10 lg:flex-row">
+          <div className="lg:w-48">
+            <div className="sticky top-32 hidden h-64 w-px overflow-hidden rounded-full bg-sky-100 lg:block">
+              <motion.div
+                style={{ scaleY: prefersReducedMotion ? 1 : progress, originY: 0 }}
+                className="h-full w-full rounded-full bg-gradient-to-b from-sky-400 to-sky-200"
+                aria-hidden="true"
+              />
+            </div>
+            <h2
+              id="company-stack-heading"
+              className="text-2xl font-semibold text-slate-900 lg:mt-4"
+            >
+              Company-Building Stack
+            </h2>
+            <p className="mt-3 text-sm text-slate-600 lg:max-w-xs">
+              Four phases, each reinforcing the next. Stay focused on the loop you can close today.
+            </p>
+          </div>
+          <div className="flex-1 space-y-6">
+            {phases.map((phase, index) => {
+              const Icon = phase.icon;
+              return (
+                <motion.article
+                  key={phase.id}
+                  initial={variants.initial}
+                  whileInView={variants.animate}
+                  viewport={{ once: true, amount: 0.25 }}
+                  transition={{ type: "spring", stiffness: 120, damping: 18, delay: index * 0.04 }}
+                  className={`group relative overflow-hidden rounded-3xl border-l-4 bg-white/90 p-6 shadow-soft backdrop-blur-sm transition-transform hover:-translate-y-1 ${phase.accent}`}
+                >
+                  <div className={`absolute inset-0 bg-gradient-to-br ${phase.gradient} opacity-0 transition-opacity duration-500 group-hover:opacity-80`} aria-hidden="true" />
+                  <div className="relative flex items-start gap-5">
+                    <motion.div
+                      className="grid h-12 w-12 place-items-center rounded-2xl bg-sky-100 text-sky-700 shadow-inner"
+                      whileHover={prefersReducedMotion ? undefined : { rotate: index === 2 ? 8 : -4, scale: 1.05 }}
+                      transition={{ type: "spring", stiffness: 160, damping: 20 }}
+                    >
+                      <Icon className="h-6 w-6" aria-hidden="true" />
+                    </motion.div>
+                    <div className="flex-1">
+                      <h3 className="text-lg font-semibold text-slate-900">{phase.title}</h3>
+                      <p className="mt-2 text-sm text-slate-700">{phase.why}</p>
+                      <ul className="mt-4 list-disc space-y-1 pl-5 text-sm text-slate-700">
+                        {phase.doNow.map((item) => (
+                          <li key={item}>{item}</li>
+                        ))}
+                      </ul>
+                      <div className="mt-4">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              type="button"
+                              className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-600 underline-offset-4 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+                              aria-label={`Benchmarks for ${phase.title}`}
+                            >
+                              Benchmarks
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <ul className="list-disc space-y-1 pl-4">
+                              {phase.benchmarks.map((benchmark) => (
+                                <li key={benchmark} className="text-xs text-slate-600">
+                                  {benchmark}
+                                </li>
+                              ))}
+                            </ul>
+                          </TooltipContent>
+                        </Tooltip>
+                      </div>
+                    </div>
+                    <motion.div
+                      className="hidden text-sky-500/80 sm:block"
+                      animate={
+                        prefersReducedMotion
+                          ? { opacity: 0.6 }
+                          : index === 2
+                            ? { rotate: 360 }
+                            : { y: [-4, 4, -4] }
+                      }
+                      transition={{
+                        repeat: prefersReducedMotion ? 0 : Infinity,
+                        duration: index === 2 ? 8 : 6,
+                        ease: "easeInOut"
+                      }}
+                      aria-hidden="true"
+                    >
+                      <Icon className="h-10 w-10" />
+                    </motion.div>
+                  </div>
+                </motion.article>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+    </TooltipProvider>
+  );
+}

--- a/components/thesis/ThesisHero.tsx
+++ b/components/thesis/ThesisHero.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import { motion, useMotionValueEvent, useReducedMotion, useScroll } from "framer-motion";
+
+const stackLayers = [
+  {
+    id: "founders",
+    title: "Founders",
+    caption: "Insight compels the earliest believers.",
+    gradient: "from-sky-100 via-white/80 to-transparent"
+  },
+  {
+    id: "distribution",
+    title: "Distribution",
+    caption: "Earned access compounds reach.",
+    gradient: "from-sky-200/70 via-white/80 to-transparent"
+  },
+  {
+    id: "product",
+    title: "Product",
+    caption: "Habit-forming loops lock in value.",
+    gradient: "from-sky-300/60 via-white/70 to-transparent"
+  },
+  {
+    id: "scale",
+    title: "Scale",
+    caption: "Economics reinforce the loop.",
+    gradient: "from-sky-400/50 via-white/60 to-transparent"
+  }
+];
+
+const heroLinks = [
+  { label: "Loops & distribution", href: "#" },
+  { label: "Founder deep dives", href: "#" },
+  { label: "Power law essays", href: "#" }
+];
+
+export default function ThesisHero() {
+  const sectionRef = useRef<HTMLDivElement | null>(null);
+  const prefersReducedMotion = useReducedMotion();
+  const { scrollYProgress } = useScroll({
+    target: sectionRef,
+    offset: ["start end", "end start"]
+  });
+  const [activeLayer, setActiveLayer] = useState(0);
+
+  useMotionValueEvent(scrollYProgress, "change", (value) => {
+    if (prefersReducedMotion) {
+      return;
+    }
+    const clamped = Math.max(0, Math.min(0.999, value));
+    const nextIndex = Math.min(
+      stackLayers.length - 1,
+      Math.floor(clamped * stackLayers.length)
+    );
+    setActiveLayer((prev) => (prev === nextIndex ? prev : nextIndex));
+  });
+
+  useEffect(() => {
+    if (prefersReducedMotion) {
+      setActiveLayer(0);
+    }
+  }, [prefersReducedMotion]);
+
+  return (
+    <section
+      ref={sectionRef}
+      className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-white via-sky-50 to-sky-100 px-6 py-20 shadow-soft"
+      aria-labelledby="thesis-hero-heading"
+    >
+      <div className="mx-auto grid max-w-6xl items-start gap-16 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.4 }}
+          transition={{ type: "spring", stiffness: 120, damping: 18 }}
+        >
+          <p className="text-sm font-medium uppercase tracking-[0.24em] text-sky-600">
+            Thesis
+          </p>
+          <h1
+            id="thesis-hero-heading"
+            className="mt-4 text-4xl font-semibold leading-tight text-slate-900 md:text-5xl"
+          >
+            The JBV Thesis
+          </h1>
+          <p className="mt-5 max-w-2xl text-lg text-slate-700">
+            Power concentrates where loops form. We back founders who move fast, earn
+            distribution, and turn usage into habit...then into durable economics.
+          </p>
+          <p className="mt-6 text-sm font-medium uppercase tracking-[0.18em] text-slate-500">
+            Power accumulates where loops form: insight → access → habit → economics.
+          </p>
+          <div className="mt-8 flex flex-wrap items-center gap-3" aria-label="Read our deep dives">
+            <span className="mr-2 text-sm font-semibold text-slate-600">Read our deep dives</span>
+            {heroLinks.map((link) => (
+              <Link
+                key={link.label}
+                href={link.href}
+                className="rounded-full border border-sky-200 bg-white/60 px-4 py-2 text-sm font-medium text-sky-700 transition-colors hover:border-sky-300 hover:bg-sky-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </motion.div>
+        <div className="relative">
+          <span className="sr-only">Animated stack of company-building phases</span>
+          <div className="relative flex h-full flex-col items-stretch justify-end gap-4">
+            {stackLayers.map((layer, index) => {
+              const isActive = prefersReducedMotion ? index === stackLayers.length - 1 : activeLayer === index;
+              const yOffset = prefersReducedMotion ? 0 : (index - activeLayer) * 14;
+              return (
+                <motion.div
+                  key={layer.id}
+                  className="relative overflow-hidden rounded-2xl border border-white/60 bg-white/80 px-6 py-6 shadow-lg backdrop-blur"
+                  style={{
+                    y: prefersReducedMotion ? 0 : yOffset
+                  }}
+                  animate={
+                    prefersReducedMotion
+                      ? { opacity: 1, scale: 1 }
+                      : {
+                          opacity: isActive ? 1 : 0.45,
+                          scale: isActive ? 1.03 : 0.94
+                        }
+                  }
+                  transition={{ type: "spring", stiffness: 160, damping: 20 }}
+                >
+                  <div className={`absolute inset-0 bg-gradient-to-br ${layer.gradient} opacity-60`} aria-hidden="true" />
+                  <div className="relative flex flex-col gap-1">
+                    <span className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                    <p className="text-lg font-semibold text-slate-900">{layer.title}</p>
+                    <p className="text-sm text-slate-600">{layer.caption}</p>
+                  </div>
+                </motion.div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import { clsx } from "clsx";
+
+const Popover = PopoverPrimitive.Root;
+const PopoverTrigger = PopoverPrimitive.Trigger;
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 12, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={clsx(
+        "z-50 w-72 rounded-2xl border border-sky-200 bg-white p-4 text-sm text-slate-700 shadow-xl shadow-sky-200/60 focus:outline-none",
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverContent };

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { clsx } from "clsx";
+
+const TooltipProvider = TooltipPrimitive.Provider;
+const Tooltip = TooltipPrimitive.Root;
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 8, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={clsx(
+      "z-50 max-w-sm rounded-xl border border-sky-200 bg-white px-3 py-2 text-xs text-slate-700 shadow-lg shadow-sky-200/60",
+      "data-[state=delayed-open]:animate-none",
+      className
+    )}
+    {...props}
+  />
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "airtable": "^0.12.2",
         "autoprefixer": "^10.4.19",
         "class-variance-authority": "^0.7.0",
@@ -175,6 +177,44 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -776,6 +816,492 @@
       "integrity": "sha512-Mdk+vUACbQvjd0m/1JJjOOafmkp/EpmHjISsopEz5Av44CBq7rPC05HHNbYGKVyNUF2zmEoBS/TT0pd0SPFFyw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
     },
     "node_modules/@react-email/render": {
       "version": "1.1.2",
@@ -1801,6 +2327,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -3073,6 +3611,12 @@
       "integrity": "sha512-I3JIbrnKPAntNLl1I6TpSQQdQ4AutYzv/sKMFKbepawV/hlH0GmYKhUoOEMd4xqaUHT+Bm0f4127lh5qs1m1tw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -4453,6 +4997,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -7437,6 +7990,75 @@
         }
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-use-measure": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
@@ -9180,6 +9802,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "postinstall": "next telemetry disable"
   },
   "dependencies": {
+    "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "airtable": "^0.12.2",
     "autoprefixer": "^10.4.19",
     "class-variance-authority": "^0.7.0",


### PR DESCRIPTION
## Summary
- rebuild the thesis route with a new hero that introduces the loop-based thesis and animated phase stack
- add dedicated components for the company-building stack, journey tracker, AI power-law timeline, glossary, and POV closing band with motion and tooltips
- introduce reusable tooltip and popover primitives powered by Radix UI and wire the page to the new structure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ced095243c8320a09915cf16ce8393