### PR TITLE
Fix tooltip rendering on Thesis benchmarks hover

### DIFF
--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -15,15 +15,17 @@ export const TooltipContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(function TooltipContent({ className, sideOffset = 8, ...props }, ref) {
   return (
-    <TooltipPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
-      className={clsx(
-        'z-50 overflow-hidden rounded-xl border border-slate-200/70 bg-white px-3 py-2 text-xs text-slate-700 shadow-lg shadow-slate-900/10 backdrop-blur',
-        className
-      )}
-      {...props}
-    />
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        ref={ref}
+        sideOffset={sideOffset}
+        className={clsx(
+          'z-50 overflow-hidden rounded-xl border border-slate-200/70 bg-white px-3 py-2 text-xs text-slate-700 shadow-lg shadow-slate-900/10 backdrop-blur',
+          className
+        )}
+        {...props}
+      />
+    </TooltipPrimitive.Portal>
   );
 });
 


### PR DESCRIPTION
## Summary
- render tooltip content through a Radix portal so it is not clipped by the Thesis card container
- keeps the existing tooltip trigger and styling intact while ensuring the Benchmarks hover works

## Testing
- Not run (next lint prompts for interactive configuration in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68cedabb119c83209e31953ee06430f5